### PR TITLE
License check

### DIFF
--- a/Deployment/RHEL7/AutoDeploy_RHEL7.sh
+++ b/Deployment/RHEL7/AutoDeploy_RHEL7.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 #  Copyright 2017 Cognizant Technology Solutions
 #  
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/Deployment/RHEL7/reference-DocRoot-Scripts/insights_agents.sh
+++ b/Deployment/RHEL7/reference-DocRoot-Scripts/insights_agents.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 echo "Set up Agent_Daemon"
 cd /opt/ && mkdir insightsagent
 chmod -R 755 insightsagent/

--- a/Deployment/RHEL7/reference-DocRoot-Scripts/insights_all.sh
+++ b/Deployment/RHEL7/reference-DocRoot-Scripts/insights_all.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 echo "Get required env varidables for Insights"
 wget http://platform.cogdevops.com/insights_install/installationScripts/latest/RHEL/scripts/insights_first.sh -O insights_first.sh  && sh insights_first.sh
 echo "Installing Java"

--- a/Deployment/RHEL7/reference-DocRoot-Scripts/insights_apache2.sh
+++ b/Deployment/RHEL7/reference-DocRoot-Scripts/insights_apache2.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 cd ~
 mkdir httpd
 cd httpd

--- a/Deployment/RHEL7/reference-DocRoot-Scripts/insights_enginejar.sh
+++ b/Deployment/RHEL7/reference-DocRoot-Scripts/insights_enginejar.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 # get insights engine jar
 echo "#################### Getting Insights Engine Jar ####################"
 sudo mkdir /opt/insightsengine

--- a/Deployment/RHEL7/reference-DocRoot-Scripts/insights_es.sh
+++ b/Deployment/RHEL7/reference-DocRoot-Scripts/insights_es.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 # install ES  - Some Issues here test on new server
 echo "#################### Installing Eleastic Search with configs ####################"
 sudo mkdir elasticsearch

--- a/Deployment/RHEL7/reference-DocRoot-Scripts/insights_first.sh
+++ b/Deployment/RHEL7/reference-DocRoot-Scripts/insights_first.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 # Set InSights Home
 echo "#################### Setting up Insights Home ####################"
 cd /usr/

--- a/Deployment/RHEL7/reference-DocRoot-Scripts/insights_grafana.sh
+++ b/Deployment/RHEL7/reference-DocRoot-Scripts/insights_grafana.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 # Install customized Grafana V4.6.2
 echo "#################### Installing Grafana (running as BG process) with user creation ####################"
 sudo mkdir grafana-v4.6.2

--- a/Deployment/RHEL7/reference-DocRoot-Scripts/insights_initscripts.sh
+++ b/Deployment/RHEL7/reference-DocRoot-Scripts/insights_initscripts.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 # This script copies all required scripts to /etc/init.d
 echo "Copying the init.d scripts"
 sudo mkdir initscripts

--- a/Deployment/RHEL7/reference-DocRoot-Scripts/insights_java.sh
+++ b/Deployment/RHEL7/reference-DocRoot-Scripts/insights_java.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 #  Copyright 2017 Cognizant Technology Solutions
 #
 #  Licensed under the Apache License, Version 2.0 (the "License"); you may not

--- a/Deployment/RHEL7/reference-DocRoot-Scripts/insights_neo4j.sh
+++ b/Deployment/RHEL7/reference-DocRoot-Scripts/insights_neo4j.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 # install neo4j
 echo "#################### Installing Neo4j with configs and user creation ####################"
 sudo sed  -i '$ a root   soft    nofile  40000' /etc/security/limits.conf

--- a/Deployment/RHEL7/reference-DocRoot-Scripts/insights_postgres.sh
+++ b/Deployment/RHEL7/reference-DocRoot-Scripts/insights_postgres.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 # install postgresql
 echo "#################### Installing Postgres with configs , Databases and Roles ####################"
 sudo yum install http://platform.cogdevops.com/insights_install/installationScripts/latest/RHEL/postgres/pgdg-redhat95-9.5-2.noarch.rpm -y

--- a/Deployment/RHEL7/reference-DocRoot-Scripts/insights_python.sh
+++ b/Deployment/RHEL7/reference-DocRoot-Scripts/insights_python.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 # Python 2.7.11
 echo "#################### Installing Python 2.7.11 with Virtual Env ####################"
 sudo mkdir python && cd python && sudo wget http://platform.cogdevops.com/insights_install/installationScripts/latest/RHEL/python/Python-2.7.11.tgz

--- a/Deployment/RHEL7/reference-DocRoot-Scripts/insights_rabbitmq.sh
+++ b/Deployment/RHEL7/reference-DocRoot-Scripts/insights_rabbitmq.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 # install erlang
 echo "#################### Installing Erlang , required for Rabbit MQ ####################"
 sudo mkdir erlang && cd erlang

--- a/Deployment/RHEL7/reference-DocRoot-Scripts/insights_tomcat8.sh
+++ b/Deployment/RHEL7/reference-DocRoot-Scripts/insights_tomcat8.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 echo "#################### Installing Tomcat8 ####################"
 cd /opt
 sudo wget  http://platform.cogdevops.com/insights_install/release/latest/InSightsUI.zip -O InSightsUI.zip

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,8 +11,8 @@ gitCommitID = sh (
 	stage ('LicenseCheck') {
            checkout scm
     	   def commit = sh (returnStdout: true, script: '''var=''
-	#for file in $(find . -print | grep -i -e .*[.]java -e .*[.]py)
-	for file in $(find . -print | grep -i -e .*[.]java)
+	for file in $(find . -print | grep -i -e .*[.]java -e .*[.]py -e .*[.]sh -e .*[.]bat )
+	#for file in $(find . -print | grep -i -e .*[.]java)
 	do
    	    if grep -q "Apache License" $file; then
         	updated="License is updated $file" ##Dummy line

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,9 +25,11 @@ gitCommitID = sh (
 	fi
 	echo " " ''').split()
 	if (fileExists('files.txt')) {
-		echo "**********************License is not updated in the following files**********************"
-    		sh 'cat files.txt'
-    		echo "*****************************************************************************************"
+		echo "#################################################################################################################"
+		echo "**********************LICENSE IS NOT UPDATED IN THE FOLLOWING LIST OF COMMA SEPARATED FILES *********************"
+		sh 'cat files.txt'
+		echo "*****************************************************************************************************************"
+		echo "#################################################################################################################"
     		slackSend channel: '#insightsjenkins', color: 'good', message: "BuildFailed for commitID - *$gitCommitID*, Branch - *$branchName* because Apache License is not updated in few files. \n List of files can be found at the bottom of the page @ https://buildon.cogdevops.com/buildon/HistoricCIWebController?commitId=$gitCommitID",  teamDomain: 'insightscogdevops',  token: slackToken
     		sh 'rm -rf files.txt'
     		sh 'exit 1'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,8 +11,7 @@ gitCommitID = sh (
 	stage ('LicenseCheck') {
            checkout scm
     	   def commit = sh (returnStdout: true, script: '''var=''
-	for file in $(find . -print | grep -i -e .*[.]java -e .*[.]py -e .*[.]sh -e .*[.]bat )
-	#for file in $(find . -print | grep -i -e .*[.]java)
+	for file in $(find . -print | grep -i -e .*[.]java -e .*[.]py -e .*[.]sh -e .*[.]bat | grep -Eiv "*__init__.py*" )
 	do
    	    if grep -q "Apache License" $file; then
         	updated="License is updated $file" ##Dummy line

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/agentdaemon/DaemonAgent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/agentdaemon/DaemonAgent.bat
@@ -1,2 +1,17 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 pushd %INSIGHTS_AGENT_HOME%\AgentDaemon
 python -c "from com.cognizant.devops.platformagents.agents.agentdaemon.AgentDaemonExecutor import AgentDaemonExecutor; AgentDaemonExecutor()"

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/agentdaemon/InSightsDaemonAgent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/agentdaemon/InSightsDaemonAgent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 #! /bin/sh
 # /etc/init.d/InSightsDaemonAgent
 

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/agentdaemon/installdaemonagent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/agentdaemon/installdaemonagent.bat
@@ -1,3 +1,18 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 REM pushd %INSIGHTS_AGENT_HOME%\AgentDaemon
 IF /I "%1%" == "UNINSTALL" (
 	net stop DaemonAgent

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/agentdaemon/installdaemonagent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/agentdaemon/installdaemonagent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 # Turn on a case-insensitive matching (-s set nocasematch)
 opt=$1
 action=$2

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/alm/hp/HpAlmAgent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/alm/hp/HpAlmAgent.bat
@@ -1,2 +1,17 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\hp
 python -c "from com.cognizant.devops.platformagents.agents.alm.hp.HpAlmAgent import HpAlmAgent; HpAlmAgent()"

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/alm/hp/InSightsHpAgent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/alm/hp/InSightsHpAgent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 #! /bin/sh
 # /etc/init.d/InSightsHpAgent
 

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/alm/hp/installagent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/alm/hp/installagent.bat
@@ -1,3 +1,18 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 REM pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\hp
 IF /I "%1%" == "UNINSTALL" (
 	net stop HpAlmAgent

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/alm/hp/installagent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/alm/hp/installagent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 # Turn on a case-insensitive matching (-s set nocasematch)
 opt=$1
 action=$2

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/alm/jira/InSightsJiraAgent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/alm/jira/InSightsJiraAgent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 #! /bin/sh
 # /etc/init.d/InSightsJiraAgent
 

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/alm/jira/JiraAgent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/alm/jira/JiraAgent.bat
@@ -1,2 +1,17 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\jira
 python -c "from com.cognizant.devops.platformagents.agents.alm.jira.JiraAgent import JiraAgent; JiraAgent()"

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/alm/jira/installagent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/alm/jira/installagent.bat
@@ -1,3 +1,18 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 REM pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\jira
 IF /I "%1%" == "UNINSTALL" (
 	net stop JiraAgent

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/alm/jira/installagent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/alm/jira/installagent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 # Turn on a case-insensitive matching (-s set nocasematch)
 opt=$1
 action=$2

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/alm/pivotalTracker/InSightsPivotalTrackerAgent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/alm/pivotalTracker/InSightsPivotalTrackerAgent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 #! /bin/sh
 # /etc/init.d/InSightsPivotalTrackerAgent
 

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/alm/pivotalTracker/PivotalTrackerAgent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/alm/pivotalTracker/PivotalTrackerAgent.bat
@@ -1,2 +1,17 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\pivotalTracker
 python -c "from com.cognizant.devops.platformagents.agents.alm.pivotalTracker.PivotalTrackerAgent import PivotalTrackerAgent; PivotalTrackerAgent()"

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/alm/pivotalTracker/installagent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/alm/pivotalTracker/installagent.bat
@@ -1,3 +1,18 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 REM pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\pivotalTracker
 nssm install PivotalTrackerAgent %INSIGHTS_AGENT_HOME%\PlatformAgents\pivotalTracker\PivotalTrackerAgent.bat
 sleep 2

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/alm/pivotalTracker/installagent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/alm/pivotalTracker/installagent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 # Turn on a case-insensitive matching (-s set nocasematch)
 opt=$1
 echo "$opt"

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/alm/rally/InSightsRallyAgent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/alm/rally/InSightsRallyAgent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 #! /bin/sh
 # /etc/init.d/InSightsRallyAgent
 

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/alm/rally/RallyAgent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/alm/rally/RallyAgent.bat
@@ -1,2 +1,17 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\rally
 python -c "from com.cognizant.devops.platformagents.agents.alm.rally.RallyAgent import RallyAgent; RallyAgent()"

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/alm/rally/installagent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/alm/rally/installagent.bat
@@ -1,3 +1,18 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 REM pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\rally
 IF /I "%1%" == "UNINSTALL" (
 	net stop RallyAgent

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/alm/rally/installagent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/alm/rally/installagent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 # Turn on a case-insensitive matching (-s set nocasematch)
 opt=$1
 action=$2

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/artifactmanagement/artifactory/ArtifactoryAgent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/artifactmanagement/artifactory/ArtifactoryAgent.bat
@@ -1,2 +1,17 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\artifactory
 python -c "from com.cognizant.devops.platformagents.agents.artifactmanagement.artifactory.ArtifactoryAgent import ArtifactoryAgent; ArtifactoryAgent()"

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/artifactmanagement/artifactory/InSightsArtifactoryAgent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/artifactmanagement/artifactory/InSightsArtifactoryAgent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 #! /bin/sh
 # /etc/init.d/InSightsArtifactoryAgent
 

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/artifactmanagement/artifactory/installagent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/artifactmanagement/artifactory/installagent.bat
@@ -1,3 +1,18 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 REM pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\artifactory
 nssm install ArtifactoryAgent %INSIGHTS_AGENT_HOME%\PlatformAgents\artifactory\ArtifactoryAgent.bat
 sleep 2

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/artifactmanagement/artifactory/installagent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/artifactmanagement/artifactory/installagent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 # Turn on a case-insensitive matching (-s set nocasematch)
 opt=$1
 echo "$opt"

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/artifactmanagement/nexus/InSightsNexusAgent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/artifactmanagement/nexus/InSightsNexusAgent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 #! /bin/sh
 # /etc/init.d/InSightsNexusAgent
 

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/artifactmanagement/nexus/NexusAgent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/artifactmanagement/nexus/NexusAgent.bat
@@ -1,2 +1,17 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\nexus
 python -c "from com.cognizant.devops.platformagents.agents.artifactmanagement.nexus.NexusAgent import NexusAgent; NexusAgent()"

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/artifactmanagement/nexus/installagent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/artifactmanagement/nexus/installagent.bat
@@ -1,3 +1,18 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 REM pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\nexus
 IF /I "%1%" == "UNINSTALL" (
 	net stop NexusAgent

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/artifactmanagement/nexus/installagent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/artifactmanagement/nexus/installagent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 # Turn on a case-insensitive matching (-s set nocasematch)
 opt=$1
 action=$2

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/circleci/CircleciAgent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/circleci/CircleciAgent.bat
@@ -1,2 +1,17 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\circleci
 python -c "from com.cognizant.devops.platformagents.agents.ci.circleci.CircleAgent import CircleAgent; CircleAgent()"

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/circleci/InSightsCircleciAgent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/circleci/InSightsCircleciAgent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 #! /bin/sh
 # /etc/init.d/InSightsCircleciAgent
 

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/circleci/installagent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/circleci/installagent.bat
@@ -1,3 +1,18 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 REM pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\circleci
 IF /I "%1%" == "UNINSTALL" (
 	net stop CircleciAgent

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/circleci/installagent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/circleci/installagent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 # Turn on a case-insensitive matching (-s set nocasematch)
 opt=$1
 action=$2

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/citfs/CITFSAgent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/citfs/CITFSAgent.bat
@@ -1,2 +1,17 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\citfs
 python -c "from com.cognizant.devops.platformagents.agents.ci.citfs.CITFSAgent import CITFSAgent; CITFSAgent()"

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/citfs/InSightsCITFSAgent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/citfs/InSightsCITFSAgent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 #! /bin/sh
 # /etc/init.d/InSightsCITFSAgent
 

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/citfs/installagent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/citfs/installagent.bat
@@ -1,3 +1,18 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 REM pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\citfs
 IF /I "%1%" == "UNINSTALL" (
 	net stop TFSAgent

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/citfs/installagent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/citfs/installagent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 # Turn on a case-insensitive matching (-s set nocasematch)
 opt=$1
 action=$2

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/concourse/ConcourseAgent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/concourse/ConcourseAgent.bat
@@ -1,2 +1,17 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\concourse
 python -c "from com.cognizant.devops.platformagents.agents.ci.concourse.ConcourseAgent import ConcourseAgent; ConcourseAgent()"

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/concourse/InSightsConcourseAgent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/concourse/InSightsConcourseAgent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 #! /bin/sh
 # /etc/init.d/InSightsConcourseAgent
 

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/concourse/installagent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/concourse/installagent.bat
@@ -1,3 +1,18 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 REM pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\concourse
 nssm install ConcourseAgent %INSIGHTS_AGENT_HOME%\PlatformAgents\concourse\ConcourseAgent.bat
 sleep 2

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/concourse/installagent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/concourse/installagent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 # Turn on a case-insensitive matching (-s set nocasematch)
 opt=$1
 echo "$opt"

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/jenkins/InSightsJenkinsAgent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/jenkins/InSightsJenkinsAgent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 #! /bin/sh
 # /etc/init.d/InSightsJenkinsAgent
 

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/jenkins/JenkinsAgent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/jenkins/JenkinsAgent.bat
@@ -1,2 +1,17 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\jenkins
 python -c "from com.cognizant.devops.platformagents.agents.ci.jenkins.JenkinsAgent import JenkinsAgent; JenkinsAgent()"

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/jenkins/installagent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/jenkins/installagent.bat
@@ -1,3 +1,18 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 REM pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\jenkins
 IF /I "%1%" == "UNINSTALL" (
 	net stop JenkinsAgent

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/jenkins/installagent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/jenkins/installagent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 # Turn on a case-insensitive matching (-s set nocasematch)
 opt=$1
 action=$2

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/jenkinsLogParser/InSightsJenkinsLogParserAgent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/jenkinsLogParser/InSightsJenkinsLogParserAgent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 #! /bin/sh
 # /etc/init.d/InSightsJenkinsLogParserAgent
 

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/jenkinsLogParser/JenkinsLogParserAgent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/jenkinsLogParser/JenkinsLogParserAgent.bat
@@ -1,2 +1,17 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\jenkinslogparser
 python -c "from com.cognizant.devops.platformagents.agents.ci.jenkinslogparser.JenkinsLogParserAgent import JenkinsLogParserAgent; JenkinsLogParserAgent()"

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/jenkinsLogParser/installagent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/jenkinsLogParser/installagent.bat
@@ -1,3 +1,18 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 REM pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\jenkinslogparser
 IF /I "%1%" == "UNINSTALL" (
 	net stop JenkinsLogParserAgent

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/jenkinsLogParser/installagent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/jenkinsLogParser/installagent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 # Turn on a case-insensitive matching (-s set nocasematch)
 opt=$1
 action=$2

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/teamcity/InSightsTeamCityAgent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/teamcity/InSightsTeamCityAgent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 #! /bin/sh
 # /etc/init.d/InSightsTeamCityAgent
 

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/teamcity/TeamCityAgent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/teamcity/TeamCityAgent.bat
@@ -1,2 +1,17 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\teamcity
 python -c "from com.cognizant.devops.platformagents.agents.ci.teamcity.TeamCityAgent import TeamCityAgent; TeamCityAgent()"

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/teamcity/installagent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/teamcity/installagent.bat
@@ -1,3 +1,18 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 REM pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\teamcity
 IF /I "%1%" == "UNINSTALL" (
 	net stop TeamCityAgent

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/teamcity/installagent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/teamcity/installagent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 # Turn on a case-insensitive matching (-s set nocasematch)
 opt=$1
 action=$2

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/codequality/sonar/InSightsSonarAgent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/codequality/sonar/InSightsSonarAgent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 #! /bin/sh
 # /etc/init.d/InSightsSonarAgent
 

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/codequality/sonar/SonarAgent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/codequality/sonar/SonarAgent.bat
@@ -1,2 +1,17 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\sonar
 python -c "from com.cognizant.devops.platformagents.agents.codequality.sonar.SonarAgent import SonarAgent; SonarAgent()"

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/codequality/sonar/installagent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/codequality/sonar/installagent.bat
@@ -1,3 +1,18 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 REM pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\sonar
 IF /I "%1%" == "UNINSTALL" (
 	net stop SonarAgent

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/codequality/sonar/installagent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/codequality/sonar/installagent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 # Turn on a case-insensitive matching (-s set nocasematch)
 opt=$1
 action=$2

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/deployment/rundeck/InSightsRundeckAgent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/deployment/rundeck/InSightsRundeckAgent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 #! /bin/sh
 # /etc/init.d/InSightsRundeckAgent
 

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/deployment/rundeck/RundeckAgent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/deployment/rundeck/RundeckAgent.bat
@@ -1,2 +1,17 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\rundeck
 python -c "from com.cognizant.devops.platformagents.agents.deployment.rundeck.RundeckAgent import RundeckAgent; RundeckAgent()"

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/deployment/rundeck/installagent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/deployment/rundeck/installagent.bat
@@ -1,3 +1,18 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 REM pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\rundeck
 IF /I "%1%" == "UNINSTALL" (
 	net stop RundeckAgent

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/deployment/rundeck/installagent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/deployment/rundeck/installagent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 # Turn on a case-insensitive matching (-s set nocasematch)
 opt=$1
 action=$2

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/deployment/ucd/InSightsUCDAgent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/deployment/ucd/InSightsUCDAgent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 #! /bin/sh
 # /etc/init.d/InSightsUCDAgent
 

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/deployment/ucd/UCDAgent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/deployment/ucd/UCDAgent.bat
@@ -1,2 +1,17 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\ucd
 python -c "from com.cognizant.devops.platformagents.agents.deployment.ucd.UrbanCodeDeployAgentAgent import UrbanCodeDeployAgentAgent; UrbanCodeDeployAgentAgent()"

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/deployment/ucd/installagent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/deployment/ucd/installagent.bat
@@ -1,3 +1,18 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 REM pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\ucd
 IF /I "%1%" == "UNINSTALL" (
 	net stop UCDAgent

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/deployment/ucd/installagent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/deployment/ucd/installagent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 # Turn on a case-insensitive matching (-s set nocasematch)
 opt=$1
 action=$2

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/deployment/xldeploy/InSightsXLDeployAgent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/deployment/xldeploy/InSightsXLDeployAgent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 #! /bin/sh
 # /etc/init.d/InSightsXLDeployAgent
 

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/deployment/xldeploy/XLDeployAgent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/deployment/xldeploy/XLDeployAgent.bat
@@ -1,2 +1,17 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\xldeploy
 python -c "from com.cognizant.devops.platformagents.agents.deployment.xldeploy.XLDeployAgentAgent import XLDeployAgentAgent; XLDeployAgentAgent()"

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/deployment/xldeploy/installagent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/deployment/xldeploy/installagent.bat
@@ -1,3 +1,18 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 REM pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\xldeploy
 IF /I "%1%" == "UNINSTALL" (
 	net stop XLDeployAgent

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/deployment/xldeploy/installagent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/deployment/xldeploy/installagent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 # Turn on a case-insensitive matching (-s set nocasematch)
 opt=$1
 action=$2

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/environment/aws/AwsAgent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/environment/aws/AwsAgent.bat
@@ -1,2 +1,17 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\aws
 python -c "from com.cognizant.devops.platformagents.agents.environment.aws.AwsAgent import AwsAgent; AwsAgent()"

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/environment/aws/InSightsAwsAgent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/environment/aws/InSightsAwsAgent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 #! /bin/sh
 # /etc/init.d/InSightsAwsAgent
 

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/environment/aws/installagent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/environment/aws/installagent.bat
@@ -1,3 +1,18 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 REM pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\aws
 IF /I "%1%" == "UNINSTALL" (
 	net stop AwsAgent

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/environment/aws/installagent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/environment/aws/installagent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 # Turn on a case-insensitive matching (-s set nocasematch)
 opt=$1
 action=$2

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/itsm/snow/InSightsSnowAgent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/itsm/snow/InSightsSnowAgent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 #! /bin/sh
 # /etc/init.d/InSightsSnowAgent
 

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/itsm/snow/SnowAgent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/itsm/snow/SnowAgent.bat
@@ -1,2 +1,17 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\snow
 python -c "from com.cognizant.devops.platformagents.agents.itsm.snow.snowAgent import snowAgent; snowAgent()"

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/itsm/snow/installagent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/itsm/snow/installagent.bat
@@ -1,3 +1,18 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 REM pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\snow
 IF /I "%1%" == "UNINSTALL" (
 	net stop SnowAgent

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/itsm/snow/installagent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/itsm/snow/installagent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 # Turn on a case-insensitive matching (-s set nocasematch)
 opt=$1
 action=$2

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/bitbucket/BitBucketAgent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/bitbucket/BitBucketAgent.bat
@@ -1,2 +1,17 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\bitbucket
 python -c "from com.cognizant.devops.platformagents.agents.scm.bitbucket.BitBucketAgent import BitBucketAgent; BitBucketAgent()"

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/bitbucket/InSightsBitBucketAgent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/bitbucket/InSightsBitBucketAgent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 #! /bin/sh
 # /etc/init.d/InSightsBitBucketAgent
 

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/bitbucket/installagent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/bitbucket/installagent.bat
@@ -1,3 +1,18 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 REM pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\bitbucket
 IF /I "%1%" == "UNINSTALL" (
 	net stop BitBucketAgent

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/bitbucket/installagent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/bitbucket/installagent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 # Turn on a case-insensitive matching (-s set nocasematch)
 opt=$1
 action=$2

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/bitbucketAllBranch/BitBucketAgentAllBranches.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/bitbucketAllBranch/BitBucketAgentAllBranches.bat
@@ -1,2 +1,17 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 pushd %INSIGHTS_AGENT_HOME%\PlatformAgents
 python -c "from com.cognizant.devops.platformagents.agents.scm.bitbucketAllBranch.BitBucketAgentAllBranches  import BitBucketAgentAllBranches; BitBucketAgentAllBranches()"

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/bitbucketAllBranch/InSightsBitBucketAgent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/bitbucketAllBranch/InSightsBitBucketAgent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 #! /bin/sh
 # /etc/init.d/InSightsBitBucketAgent
 

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/bitbucketAllBranch/InSightsBitBucketAgentAllbranch.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/bitbucketAllBranch/InSightsBitBucketAgentAllbranch.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 #! /bin/sh
 # /etc/init.d/InSightsBitBucketAgent
 

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/bitbucketAllBranch/installagent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/bitbucketAllBranch/installagent.bat
@@ -1,3 +1,18 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 REM pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\bitbucketAllBranch
 IF /I "%1%" == "UNINSTALL" (
 	net stop BitBucketAgent

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/bitbucketAllBranch/installagent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/bitbucketAllBranch/installagent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 # Turn on a case-insensitive matching (-s set nocasematch)
 opt=$1
 action=$2

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/bitbucketcloud/BitBucketCloudAgent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/bitbucketcloud/BitBucketCloudAgent.bat
@@ -1,2 +1,17 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\bitbucketcloud
 python -c "from com.cognizant.devops.platformagents.agents.scm.bitbucketcloud.BitBucketCloudAgent import BitBucketCloudAgent; BitBucketCloudAgent()"

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/bitbucketcloud/InSightsBitBucketCloudAgent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/bitbucketcloud/InSightsBitBucketCloudAgent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 #! /bin/sh
 # /etc/init.d/InSightsBitBucketCloudAgent
 

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/bitbucketcloud/installagent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/bitbucketcloud/installagent.bat
@@ -1,3 +1,18 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 REM pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\bitbucketcloud
 IF /I "%1%" == "UNINSTALL" (
 	net stop BitBucketCloudAgent

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/bitbucketcloud/installagent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/bitbucketcloud/installagent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 # Turn on a case-insensitive matching (-s set nocasematch)
 opt=$1
 action=$2

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/git/GitAgent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/git/GitAgent.bat
@@ -1,2 +1,17 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\git
 python -c "from com.cognizant.devops.platformagents.agents.scm.git.GitAgent import GitAgent; GitAgent()"

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/git/InSightsGitAgent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/git/InSightsGitAgent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 #! /bin/sh
 # /etc/init.d/InSightsGitAgent
 

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/git/installagent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/git/installagent.bat
@@ -1,3 +1,18 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 REM pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\git
 IF /I "%1%" == "UNINSTALL" (
 	net stop GitAgent

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/git/installagent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/git/installagent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 # Turn on a case-insensitive matching (-s set nocasematch)
 opt=$1
 action=$2

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/svn/InSightsSvnAgent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/svn/InSightsSvnAgent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 #! /bin/sh
 # /etc/init.d/InSightsSvnAgent
 

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/svn/SvnAgent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/svn/SvnAgent.bat
@@ -1,2 +1,17 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\svn
 python -c "from com.cognizant.devops.platformagents.agents.scm.svn.svnAgent import svnAgent; svnAgent()"

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/svn/installagent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/svn/installagent.bat
@@ -1,3 +1,18 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 REM pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\svn
 IF /I "%1%" == "UNINSTALL" (
 	net stop svnAgent

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/svn/installagent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/svn/installagent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 # Turn on a case-insensitive matching (-s set nocasematch)
 opt=$1
 action=$2

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/tfs/InSightsTFSAgent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/tfs/InSightsTFSAgent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 #! /bin/sh
 # /etc/init.d/InSightsTFSAgent
 

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/tfs/TFSAgent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/tfs/TFSAgent.bat
@@ -1,2 +1,17 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\tfs
 python -c "from com.cognizant.devops.platformagents.agents.scm.tfs.TFSAgent import TFSAgent; TFSAgent()"

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/tfs/installagent.bat
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/tfs/installagent.bat
@@ -1,3 +1,18 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 REM pushd %INSIGHTS_AGENT_HOME%\PlatformAgents\tfs
 IF /I "%1%" == "UNINSTALL" (
 	net stop TFSAgent

--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/tfs/installagent.sh
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/scm/tfs/installagent.sh
@@ -1,3 +1,18 @@
+#-------------------------------------------------------------------------------
+# Copyright 2017 Cognizant Technology Solutions
+#   
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#-------------------------------------------------------------------------------
 # Turn on a case-insensitive matching (-s set nocasematch)
 opt=$1
 action=$2

--- a/PlatformGrafanaPlugins/GrafanaCustomization/v4.2.0/GrafanaDevSetUp.bat
+++ b/PlatformGrafanaPlugins/GrafanaCustomization/v4.2.0/GrafanaDevSetUp.bat
@@ -1,3 +1,18 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 go get github.com/grafana/grafana
 set GRFANA_DEV_PATH=%GOPATH%\src\github.com\grafana\grafana
 pushd %GRFANA_DEV_PATH%

--- a/PlatformUI2.0/UIcomponents.bat
+++ b/PlatformUI2.0/UIcomponents.bat
@@ -1,3 +1,18 @@
+goto comment
+Copyright 2017 Cognizant Technology Solutions
+  
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.  You may obtain a copy
+of the License at
+  
+http://www.apache.org/licenses/LICENSE-2.0
+  
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+License for the specific language governing permissions and limitations under
+the License.
+:comment
 pushd PlatformUI2.0
 bower install --config.strict-ssl=false --config.proxy= --config.https-proxy= --force
 npm install

--- a/desktop.ini
+++ b/desktop.ini
@@ -1,0 +1,4 @@
+[ViewState]
+Mode=
+Vid=
+FolderType=Generic


### PR DESCRIPTION
Added Copyright in Shell and Bat files. Included logic to handle Copyright check for Python, Shell and Bat files.