### PR TITLE
Fixing issues of exception in jira agent when sprint field was having…

### DIFF
--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/alm/jira/JiraAgent.py
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/alm/jira/JiraAgent.py
@@ -159,7 +159,8 @@ class JiraAgent(BaseAgent):
                     sprintPropertieTokens = sprintDetail.split(",")
                     for propertyToken in sprintPropertieTokens:
                         propertyKeyValToken = propertyToken.split("=")
-                        sprintData[propertyKeyValToken[0]] = propertyKeyValToken[1]
+                        if len(propertyKeyValToken) > 1:
+                            sprintData[propertyKeyValToken[0]] = propertyKeyValToken[1]
                     boardId = sprintData.get('rapidViewId')
                     sprintId = sprintData.get('id')
                     boardTracking = boardsTracking.get(boardId, None)


### PR DESCRIPTION
Fixing issues of exception in jira agent when sprint field was having goal field with "," field. "goal=Define Scope for Accordion, Complete Icon Link,"

example "customfield_10000": [
          "com.atlassian.greenhopper.service.sprint.Sprint@77c19629[id=266,rapidViewId=174,state=CLOSED,name=GSC Sprint 26,startDate=2018-03-06T09:10:57.810-08:00,endDate=2018-03-19T09:10:00.000-07:00,completeDate=2018-03-20T07:07:14.478-07:00,sequence=266,goal=<null>]",
          "com.atlassian.greenhopper.service.sprint.Sprint@658a6b7d[id=318,rapidViewId=174,state=CLOSED,name=GSC Sprint 30,startDate=2018-05-01T09:24:47.212-07:00,endDate=2018-05-15T09:00:00.000-07:00,completeDate=2018-05-14T15:55:48.913-07:00,sequence=318,goal=Define Scope for Accordion, Complete Icon Link,]",
          "com.atlassian.greenhopper.service.sprint.Sprint@59411d13[id=518,rapidViewId=174,state=FUTURE,name=GSC Sprint 37,startDate=<null>,endDate=<null>,completeDate=<null>,sequence=518,goal=<null>]"
        ],