### PR TITLE
Code changes for Query Caching fault tolerance

### DIFF
--- a/PlatformService/src/main/java/com/cognizant/devops/platformservice/rest/querycaching/service/QueryCachingServiceImpl.java
+++ b/PlatformService/src/main/java/com/cognizant/devops/platformservice/rest/querycaching/service/QueryCachingServiceImpl.java
@@ -184,6 +184,11 @@ public class QueryCachingServiceImpl implements QueryCachingService {
 
 		} catch (Exception e) {
 			log.error("Error in capturing Elasticsearch response", e);
+			try {
+				return getNeo4jDatasource(requestPayload);
+			} catch (GraphDBException graphDBEx) {
+				log.error("Exception in neo4j query execution", graphDBEx);
+			}
 		}
 
 		return null;


### PR DESCRIPTION
These code changes are done to achieve Query Caching fault tolerance. The scenario should be that if the ES instance is not reachable or we have a timeout during the fetch of data - we should be able to download the data from Neo4j directly. This will ensure that the panels will always have data irrespective of the fact whether ES is reachable or not. 