### PR TITLE
#165207024 Adding correct import line with relative statement in log …

### DIFF
--- a/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/jenkinsLogParser/JenkinsLogParserAgent.py
+++ b/PlatformAgents/com/cognizant/devops/platformagents/agents/ci/jenkinsLogParser/JenkinsLogParserAgent.py
@@ -22,7 +22,7 @@ import requests
 from requests.auth import HTTPBasicAuth
 import json
 import copy
-from ....core.BaseAgent import BaseAgent
+from ....agents.ci.jenkins.JenkinsAgent import JenkinsAgent
 
 
 class JenkinsLogParserAgent(JenkinsAgent):         


### PR DESCRIPTION
Jenkins Log parser not working in latest 5.0 release. Due to this we have added relative import statement.